### PR TITLE
refactor: prevent to run the code on preview mode

### DIFF
--- a/packages/integration/src/index.ts
+++ b/packages/integration/src/index.ts
@@ -14,7 +14,8 @@ export default function integration(): AstroIntegration {
         hooks: {
             // TODO: handle refresh when new routes are created or deleted
             'astro:config:setup': ({ injectRoute, config, command }) => {
-                if (command === 'build') {
+                // we will prevent to run the next code when is build or preview
+                if (command === 'build' || command === 'preview') {
                     return;
                 }
                 let pagesDir = new URL('./src/pages', config.root);


### PR DESCRIPTION
This PR prevent to run the whole code when are in preview mode, since preview mode is basically the production version of astro, so we don't want to run the code in that mode.

